### PR TITLE
feat(data-plane): REQ-DP-03 caller/callee traversal API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2269,6 +2269,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rb-query"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "base64 0.22.1",
+ "neo4rs",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2427,6 +2440,7 @@ dependencies = [
  "anyhow",
  "async-stream",
  "axum",
+ "base64 0.22.1",
  "chrono",
  "config",
  "futures-util",
@@ -2436,6 +2450,7 @@ dependencies = [
  "moka",
  "neo4rs",
  "prometheus",
+ "rb-query",
  "reqwest",
  "rustbrain-common",
  "serde",
@@ -3265,15 +3280,6 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "test-fixture"
-version = "0.1.0"
-dependencies = [
- "async-trait",
- "serde",
- "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 resolver = "2"
 members = [
     "crates/rustbrain-common",
+    "crates/rb-query",
     "services/ingestion",
     "services/api",
     "services/audit",

--- a/crates/rb-query/Cargo.toml
+++ b/crates/rb-query/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "rb-query"
+version = "0.1.0"
+edition = "2021"
+description = "Call-graph traversal engine for rust-brain data-plane queries (REQ-DP-03)"
+
+[dependencies]
+neo4rs = "0.7"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+anyhow = "1.0"
+base64 = "0.22"
+tracing = "0.1"
+
+[dev-dependencies]
+tokio = { version = "1.37", features = ["full"] }

--- a/crates/rb-query/src/cursor.rs
+++ b/crates/rb-query/src/cursor.rs
@@ -1,0 +1,71 @@
+//! Opaque cursor encoding for pagination.
+//!
+//! A cursor is `base64url(json({"offset": N}))`. Callers receive a `next_cursor`
+//! and pass it back as `?cursor=...` to advance through a result set.
+
+use anyhow::{bail, Result};
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize)]
+struct CursorPayload {
+    offset: usize,
+}
+
+/// Encode an offset into an opaque cursor string.
+pub fn encode(offset: usize) -> String {
+    let payload = serde_json::to_string(&CursorPayload { offset }).unwrap_or_default();
+    URL_SAFE_NO_PAD.encode(payload.as_bytes())
+}
+
+/// Decode an opaque cursor string into an offset.
+///
+/// Returns `Ok(0)` when `cursor` is `None`.
+pub fn decode(cursor: Option<&str>) -> Result<usize> {
+    let Some(s) = cursor else {
+        return Ok(0);
+    };
+    let bytes = URL_SAFE_NO_PAD
+        .decode(s)
+        .map_err(|_| anyhow::anyhow!("invalid cursor: base64 decode failed"))?;
+    let payload: CursorPayload = serde_json::from_slice(&bytes)
+        .map_err(|_| anyhow::anyhow!("invalid cursor: JSON decode failed"))?;
+    if payload.offset > 1_000_000 {
+        bail!("invalid cursor: offset out of range");
+    }
+    Ok(payload.offset)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn round_trip() {
+        let cursor = encode(42);
+        let offset = decode(Some(&cursor)).unwrap();
+        assert_eq!(offset, 42);
+    }
+
+    #[test]
+    fn none_cursor_is_zero() {
+        assert_eq!(decode(None).unwrap(), 0);
+    }
+
+    #[test]
+    fn rejects_garbage() {
+        assert!(decode(Some("not-base64!!!")).is_err());
+    }
+
+    #[test]
+    fn rejects_invalid_json_payload() {
+        let garbage = URL_SAFE_NO_PAD.encode(b"not json");
+        assert!(decode(Some(&garbage)).is_err());
+    }
+
+    #[test]
+    fn zero_offset_cursor() {
+        let cursor = encode(0);
+        assert_eq!(decode(Some(&cursor)).unwrap(), 0);
+    }
+}

--- a/crates/rb-query/src/lib.rs
+++ b/crates/rb-query/src/lib.rs
@@ -1,0 +1,23 @@
+//! Call-graph traversal engine for rust-brain data-plane queries.
+//!
+//! Implements REQ-DP-03: depth-limited BFS over `CALLS` and `CALL_INSTANTIATES`
+//! edges in Neo4j with per-edge provenance, cycle detection, and cursor-based
+//! pagination.
+//!
+//! # Usage
+//!
+//! ```ignore
+//! use rb_query::{CallGraphTraverser, TraversalOptions};
+//! use std::sync::Arc;
+//!
+//! let traverser = CallGraphTraverser::new(graph, "Workspace_abc123".to_string());
+//! let opts = TraversalOptions::default();
+//! let result = traverser.get_callers("crate::module::func", opts).await?;
+//! ```
+
+pub mod cursor;
+pub mod traversal;
+pub mod types;
+
+pub use traversal::CallGraphTraverser;
+pub use types::{EdgeProvenance, TraversalEdge, TraversalNode, TraversalOptions, TraversalResult};

--- a/crates/rb-query/src/traversal.rs
+++ b/crates/rb-query/src/traversal.rs
@@ -1,0 +1,539 @@
+//! BFS call-graph traversal over Neo4j CALLS / CALL_INSTANTIATES edges.
+//!
+//! # Provenance mapping
+//!
+//! | Neo4j edge type   | CALLS.dispatch property | Provenance    |
+//! |-------------------|-------------------------|---------------|
+//! | CALLS             | "dynamic"               | dyn_candidate |
+//! | CALLS             | any, non-empty types    | monomorph     |
+//! | CALLS             | "static" / absent       | direct        |
+//! | CALL_INSTANTIATES | —                       | monomorph     |
+//!
+//! # Multi-tenancy
+//!
+//! Every Cypher pattern matches against the composite workspace label
+//! (e.g., `Workspace_550e8400e29b`) injected at query time.
+
+use std::{
+    collections::{HashMap, HashSet, VecDeque},
+    sync::Arc,
+};
+
+use anyhow::{Context, Result};
+use neo4rs::{query, Graph};
+use tracing::debug;
+
+use crate::{
+    cursor,
+    types::{EdgeProvenance, TraversalEdge, TraversalNode, TraversalOptions, TraversalResult},
+};
+
+/// Entry point for caller/callee graph traversal.
+pub struct CallGraphTraverser {
+    graph: Arc<Graph>,
+    /// Neo4j composite workspace label, e.g. `Workspace_550e8400e29b`.
+    workspace_label: String,
+}
+
+impl CallGraphTraverser {
+    pub fn new(graph: Arc<Graph>, workspace_label: String) -> Self {
+        Self {
+            graph,
+            workspace_label,
+        }
+    }
+
+    /// Traverse callers of `root_fqn` via backward BFS over CALLS / CALL_INSTANTIATES.
+    pub async fn get_callers(
+        &self,
+        root_fqn: &str,
+        opts: TraversalOptions,
+    ) -> Result<TraversalResult> {
+        let opts = opts.clamp();
+        let offset = cursor::decode(opts.cursor.as_deref())
+            .context("invalid cursor in get_callers")?;
+
+        let root = self.fetch_node(root_fqn).await?;
+
+        let (edges, cycles_detected) = self
+            .bfs_callers(root_fqn, opts.depth, opts.limit + offset)
+            .await?;
+
+        build_result(root, edges, cycles_detected, offset, opts.limit)
+    }
+
+    /// Traverse callees of `root_fqn` via forward BFS over CALLS / CALL_INSTANTIATES.
+    pub async fn get_callees(
+        &self,
+        root_fqn: &str,
+        opts: TraversalOptions,
+    ) -> Result<TraversalResult> {
+        let opts = opts.clamp();
+        let offset = cursor::decode(opts.cursor.as_deref())
+            .context("invalid cursor in get_callees")?;
+
+        let root = self.fetch_node(root_fqn).await?;
+
+        let (edges, cycles_detected) = self
+            .bfs_callees(root_fqn, opts.depth, opts.limit + offset)
+            .await?;
+
+        build_result(root, edges, cycles_detected, offset, opts.limit)
+    }
+
+    // ── internals ─────────────────────────────────────────────────────────────
+
+    /// Fetch the root node's metadata from Neo4j.
+    async fn fetch_node(&self, fqn: &str) -> Result<TraversalNode> {
+        let ws = &self.workspace_label;
+        let cypher = format!(
+            "MATCH (n:{ws}) WHERE n.fqn = $fqn \
+             RETURN n.fqn AS fqn, n.name AS name, \
+             labels(n)[0] AS kind, n.file_path AS file_path, n.start_line AS line \
+             LIMIT 1"
+        );
+
+        let mut result = self
+            .graph
+            .execute(query(&cypher).param("fqn", fqn))
+            .await
+            .context("fetch_node query failed")?;
+
+        if let Some(row) = result
+            .next()
+            .await
+            .context("fetch_node row fetch failed")?
+        {
+            Ok(TraversalNode {
+                fqn: row.get::<String>("fqn").unwrap_or_else(|_| fqn.to_string()),
+                name: row
+                    .get::<String>("name")
+                    .unwrap_or_else(|_| fqn.split("::").last().unwrap_or(fqn).to_string()),
+                kind: row.get::<String>("kind").ok(),
+                file_path: row.get::<String>("file_path").ok(),
+                line: row.get::<i64>("line").ok().map(|l| l as u32),
+            })
+        } else {
+            // Root might not be in the graph yet; return minimal stub
+            Ok(TraversalNode {
+                fqn: fqn.to_string(),
+                name: fqn.split("::").last().unwrap_or(fqn).to_string(),
+                kind: None,
+                file_path: None,
+                line: None,
+            })
+        }
+    }
+
+    /// BFS backward: find all callers of `root_fqn` up to `max_depth` hops.
+    ///
+    /// Returns collected edges (in BFS order) and whether any cycle was detected.
+    async fn bfs_callers(
+        &self,
+        root_fqn: &str,
+        max_depth: u32,
+        max_edges: usize,
+    ) -> Result<(Vec<TraversalEdge>, bool)> {
+        let ws = &self.workspace_label;
+        let mut edges: Vec<TraversalEdge> = Vec::new();
+        let mut visited: HashSet<String> = HashSet::new();
+        let mut cycles_detected = false;
+
+        visited.insert(root_fqn.to_string());
+
+        // BFS queue: (fqn, depth)
+        let mut frontier: VecDeque<(String, u32)> = VecDeque::new();
+        frontier.push_back((root_fqn.to_string(), 0));
+
+        while let Some((current_fqn, depth)) = frontier.pop_front() {
+            if depth >= max_depth || edges.len() >= max_edges {
+                break;
+            }
+
+            let callers = self
+                .query_callers_of(ws, &current_fqn)
+                .await
+                .with_context(|| format!("query_callers_of({current_fqn}) failed"))?;
+
+            for (caller_node, provenance) in callers {
+                if visited.contains(&caller_node.fqn) {
+                    cycles_detected = true;
+                    continue;
+                }
+                visited.insert(caller_node.fqn.clone());
+
+                edges.push(TraversalEdge {
+                    from_fqn: caller_node.fqn.clone(),
+                    to_fqn: current_fqn.clone(),
+                    depth: depth + 1,
+                    provenance,
+                });
+
+                if edges.len() < max_edges {
+                    frontier.push_back((caller_node.fqn, depth + 1));
+                }
+            }
+        }
+
+        Ok((edges, cycles_detected))
+    }
+
+    /// BFS forward: find all callees of `root_fqn` up to `max_depth` hops.
+    async fn bfs_callees(
+        &self,
+        root_fqn: &str,
+        max_depth: u32,
+        max_edges: usize,
+    ) -> Result<(Vec<TraversalEdge>, bool)> {
+        let ws = &self.workspace_label;
+        let mut edges: Vec<TraversalEdge> = Vec::new();
+        let mut visited: HashSet<String> = HashSet::new();
+        let mut cycles_detected = false;
+
+        visited.insert(root_fqn.to_string());
+
+        let mut frontier: VecDeque<(String, u32)> = VecDeque::new();
+        frontier.push_back((root_fqn.to_string(), 0));
+
+        while let Some((current_fqn, depth)) = frontier.pop_front() {
+            if depth >= max_depth || edges.len() >= max_edges {
+                break;
+            }
+
+            let callees = self
+                .query_callees_of(ws, &current_fqn)
+                .await
+                .with_context(|| format!("query_callees_of({current_fqn}) failed"))?;
+
+            for (callee_node, provenance) in callees {
+                if visited.contains(&callee_node.fqn) {
+                    cycles_detected = true;
+                    continue;
+                }
+                visited.insert(callee_node.fqn.clone());
+
+                edges.push(TraversalEdge {
+                    from_fqn: current_fqn.clone(),
+                    to_fqn: callee_node.fqn.clone(),
+                    depth: depth + 1,
+                    provenance,
+                });
+
+                if edges.len() < max_edges {
+                    frontier.push_back((callee_node.fqn, depth + 1));
+                }
+            }
+        }
+
+        Ok((edges, cycles_detected))
+    }
+
+    /// Single-level backward neighbor query: nodes that have CALLS or
+    /// CALL_INSTANTIATES edges pointing TO `target_fqn`.
+    async fn query_callers_of(
+        &self,
+        ws: &str,
+        target_fqn: &str,
+    ) -> Result<Vec<(TraversalNode, EdgeProvenance)>> {
+        // Query CALLS edges
+        let calls_cypher = format!(
+            "MATCH (caller:{ws})-[r:CALLS]->(target:{ws} {{fqn: $fqn}}) \
+             RETURN caller.fqn AS fqn, caller.name AS name, \
+             labels(caller)[0] AS kind, caller.file_path AS file_path, \
+             caller.start_line AS line, \
+             r.dispatch AS dispatch, \
+             size(coalesce(r.concrete_types, [])) AS type_count \
+             LIMIT 500"
+        );
+
+        // Query CALL_INSTANTIATES edges (may return 0 rows if edge type not yet populated)
+        let ci_cypher = format!(
+            "MATCH (caller:{ws})-[r:CALL_INSTANTIATES]->(target:{ws} {{fqn: $fqn}}) \
+             RETURN caller.fqn AS fqn, caller.name AS name, \
+             labels(caller)[0] AS kind, caller.file_path AS file_path, \
+             caller.start_line AS line, \
+             null AS dispatch, \
+             0 AS type_count \
+             LIMIT 500"
+        );
+
+        let mut results = Vec::new();
+        for (cypher, is_instantiates) in [(&calls_cypher, false), (&ci_cypher, true)] {
+            let mut rows = self
+                .graph
+                .execute(query(cypher).param("fqn", target_fqn))
+                .await
+                .context("caller query failed")?;
+
+            while let Some(row) = rows.next().await.context("caller row failed")? {
+                let fqn = match row.get::<String>("fqn") {
+                    Ok(f) => f,
+                    Err(_) => continue,
+                };
+                let node = TraversalNode {
+                    name: row
+                        .get::<String>("name")
+                        .unwrap_or_else(|_| fqn.split("::").last().unwrap_or(&fqn).to_string()),
+                    kind: row.get::<String>("kind").ok(),
+                    file_path: row.get::<String>("file_path").ok(),
+                    line: row.get::<i64>("line").ok().map(|l| l as u32),
+                    fqn,
+                };
+                let provenance = if is_instantiates {
+                    EdgeProvenance::Monomorph
+                } else {
+                    provenance_from_row(
+                        row.get::<String>("dispatch").ok().as_deref(),
+                        row.get::<i64>("type_count").unwrap_or(0),
+                    )
+                };
+                debug!(fqn = %node.fqn, ?provenance, "caller discovered");
+                results.push((node, provenance));
+            }
+        }
+
+        Ok(results)
+    }
+
+    /// Single-level forward neighbor query: nodes called by `source_fqn`.
+    async fn query_callees_of(
+        &self,
+        ws: &str,
+        source_fqn: &str,
+    ) -> Result<Vec<(TraversalNode, EdgeProvenance)>> {
+        let calls_cypher = format!(
+            "MATCH (source:{ws} {{fqn: $fqn}})-[r:CALLS]->(callee:{ws}) \
+             RETURN callee.fqn AS fqn, callee.name AS name, \
+             labels(callee)[0] AS kind, callee.file_path AS file_path, \
+             callee.start_line AS line, \
+             r.dispatch AS dispatch, \
+             size(coalesce(r.concrete_types, [])) AS type_count \
+             LIMIT 500"
+        );
+
+        let ci_cypher = format!(
+            "MATCH (source:{ws} {{fqn: $fqn}})-[r:CALL_INSTANTIATES]->(callee:{ws}) \
+             RETURN callee.fqn AS fqn, callee.name AS name, \
+             labels(callee)[0] AS kind, callee.file_path AS file_path, \
+             callee.start_line AS line, \
+             null AS dispatch, \
+             0 AS type_count \
+             LIMIT 500"
+        );
+
+        let mut results = Vec::new();
+        for (cypher, is_instantiates) in [(&calls_cypher, false), (&ci_cypher, true)] {
+            let mut rows = self
+                .graph
+                .execute(query(cypher).param("fqn", source_fqn))
+                .await
+                .context("callee query failed")?;
+
+            while let Some(row) = rows.next().await.context("callee row failed")? {
+                let fqn = match row.get::<String>("fqn") {
+                    Ok(f) => f,
+                    Err(_) => continue,
+                };
+                let node = TraversalNode {
+                    name: row
+                        .get::<String>("name")
+                        .unwrap_or_else(|_| fqn.split("::").last().unwrap_or(&fqn).to_string()),
+                    kind: row.get::<String>("kind").ok(),
+                    file_path: row.get::<String>("file_path").ok(),
+                    line: row.get::<i64>("line").ok().map(|l| l as u32),
+                    fqn,
+                };
+                let provenance = if is_instantiates {
+                    EdgeProvenance::Monomorph
+                } else {
+                    provenance_from_row(
+                        row.get::<String>("dispatch").ok().as_deref(),
+                        row.get::<i64>("type_count").unwrap_or(0),
+                    )
+                };
+                debug!(fqn = %node.fqn, ?provenance, "callee discovered");
+                results.push((node, provenance));
+            }
+        }
+
+        Ok(results)
+    }
+}
+
+/// Determine provenance from CALLS relationship properties.
+fn provenance_from_row(dispatch: Option<&str>, type_count: i64) -> EdgeProvenance {
+    match dispatch {
+        Some("dynamic") => EdgeProvenance::DynCandidate,
+        _ if type_count > 0 => EdgeProvenance::Monomorph,
+        _ => EdgeProvenance::Direct,
+    }
+}
+
+/// Slice collected edges using cursor offset and limit, build TraversalResult.
+fn build_result(
+    root: TraversalNode,
+    all_edges: Vec<TraversalEdge>,
+    cycles_detected: bool,
+    offset: usize,
+    limit: usize,
+) -> Result<TraversalResult> {
+    let total = all_edges.len();
+    let page: Vec<TraversalEdge> = all_edges
+        .into_iter()
+        .skip(offset)
+        .take(limit)
+        .collect();
+
+    let has_more = offset + page.len() < total;
+    let next_cursor = if has_more {
+        Some(cursor::encode(offset + page.len()))
+    } else {
+        None
+    };
+
+    // Collect unique non-root nodes referenced by the page edges
+    let mut seen_fqns: HashSet<String> = HashSet::new();
+    seen_fqns.insert(root.fqn.clone());
+
+    let mut nodes: Vec<TraversalNode> = Vec::new();
+    // We only have FQN + name in edges; build stub nodes from edge data
+    let mut node_index: HashMap<String, TraversalNode> = HashMap::new();
+    for edge in &page {
+        for fqn in [&edge.from_fqn, &edge.to_fqn] {
+            if !seen_fqns.contains(fqn) {
+                seen_fqns.insert(fqn.clone());
+                node_index.entry(fqn.clone()).or_insert_with(|| TraversalNode {
+                    fqn: fqn.clone(),
+                    name: fqn.split("::").last().unwrap_or(fqn).to_string(),
+                    kind: None,
+                    file_path: None,
+                    line: None,
+                });
+            }
+        }
+    }
+    nodes.extend(node_index.into_values());
+    nodes.sort_by(|a, b| a.fqn.cmp(&b.fqn));
+
+    Ok(TraversalResult {
+        root,
+        nodes,
+        edges: page,
+        cycles_detected,
+        next_cursor,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::DEFAULT_LIMIT;
+
+    fn make_edge(from: &str, to: &str, depth: u32) -> TraversalEdge {
+        TraversalEdge {
+            from_fqn: from.to_string(),
+            to_fqn: to.to_string(),
+            depth,
+            provenance: EdgeProvenance::Direct,
+        }
+    }
+
+    fn make_root(fqn: &str) -> TraversalNode {
+        TraversalNode {
+            fqn: fqn.to_string(),
+            name: fqn.to_string(),
+            kind: None,
+            file_path: None,
+            line: None,
+        }
+    }
+
+    #[test]
+    fn provenance_dynamic_dispatch() {
+        assert_eq!(
+            provenance_from_row(Some("dynamic"), 0),
+            EdgeProvenance::DynCandidate
+        );
+    }
+
+    #[test]
+    fn provenance_with_concrete_types() {
+        assert_eq!(
+            provenance_from_row(Some("static"), 3),
+            EdgeProvenance::Monomorph
+        );
+    }
+
+    #[test]
+    fn provenance_plain_static() {
+        assert_eq!(provenance_from_row(Some("static"), 0), EdgeProvenance::Direct);
+    }
+
+    #[test]
+    fn provenance_absent_dispatch() {
+        assert_eq!(provenance_from_row(None, 0), EdgeProvenance::Direct);
+    }
+
+    #[test]
+    fn build_result_first_page() {
+        let root = make_root("root");
+        let edges = vec![
+            make_edge("a", "root", 1),
+            make_edge("b", "root", 1),
+            make_edge("c", "a", 2),
+        ];
+        let result = build_result(root, edges, false, 0, 2).unwrap();
+        assert_eq!(result.edges.len(), 2);
+        assert!(result.next_cursor.is_some());
+        assert!(!result.cycles_detected);
+    }
+
+    #[test]
+    fn build_result_last_page() {
+        let root = make_root("root");
+        let edges = vec![make_edge("a", "root", 1), make_edge("b", "root", 1)];
+        let result = build_result(root, edges, false, 1, DEFAULT_LIMIT).unwrap();
+        assert_eq!(result.edges.len(), 1);
+        assert!(result.next_cursor.is_none());
+    }
+
+    #[test]
+    fn build_result_cycles_flag_propagated() {
+        let root = make_root("root");
+        let result = build_result(root, vec![], true, 0, DEFAULT_LIMIT).unwrap();
+        assert!(result.cycles_detected);
+    }
+
+    #[test]
+    fn build_result_nodes_exclude_root() {
+        let root = make_root("root::fn");
+        let edges = vec![make_edge("caller::fn", "root::fn", 1)];
+        let result = build_result(root, edges, false, 0, DEFAULT_LIMIT).unwrap();
+        // nodes should contain "caller::fn" but not "root::fn"
+        assert!(result.nodes.iter().any(|n| n.fqn == "caller::fn"));
+        assert!(!result.nodes.iter().any(|n| n.fqn == "root::fn"));
+    }
+
+    #[test]
+    fn build_result_nodes_deduped() {
+        let root = make_root("root");
+        let edges = vec![
+            make_edge("a", "root", 1),
+            make_edge("b", "a", 2),
+            make_edge("a", "b", 3), // 'a' appears again
+        ];
+        let result = build_result(root, edges, false, 0, DEFAULT_LIMIT).unwrap();
+        let fqns: Vec<&str> = result.nodes.iter().map(|n| n.fqn.as_str()).collect();
+        let unique: HashSet<&str> = fqns.iter().copied().collect();
+        assert_eq!(fqns.len(), unique.len(), "nodes must be unique");
+    }
+
+    #[test]
+    fn build_result_empty_edges_no_cursor() {
+        let root = make_root("root");
+        let result = build_result(root, vec![], false, 0, DEFAULT_LIMIT).unwrap();
+        assert!(result.next_cursor.is_none());
+        assert!(result.nodes.is_empty());
+        assert!(result.edges.is_empty());
+    }
+}

--- a/crates/rb-query/src/types.rs
+++ b/crates/rb-query/src/types.rs
@@ -1,0 +1,122 @@
+//! Public types for the caller/callee traversal API (REQ-DP-03).
+
+use serde::{Deserialize, Serialize};
+
+pub const DEFAULT_DEPTH: u32 = 3;
+pub const MAX_DEPTH: u32 = 10;
+pub const DEFAULT_LIMIT: usize = 50;
+pub const MAX_LIMIT: usize = 200;
+
+/// Per-edge dispatch provenance returned in traversal results.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EdgeProvenance {
+    /// Static direct call — CALLS edge with static dispatch.
+    Direct,
+    /// Monomorphized generic instantiation — CALL_INSTANTIATES edge or CALLS
+    /// edge carrying concrete type arguments.
+    Monomorph,
+    /// Dynamic dispatch candidate — CALLS edge with `dispatch = "dynamic"`.
+    DynCandidate,
+}
+
+/// A node discovered during BFS traversal.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TraversalNode {
+    pub fqn: String,
+    pub name: String,
+    pub kind: Option<String>,
+    pub file_path: Option<String>,
+    pub line: Option<u32>,
+}
+
+/// A directed edge discovered during BFS traversal.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TraversalEdge {
+    /// FQN of the calling node (for callers traversal) or source node (for callees traversal).
+    pub from_fqn: String,
+    /// FQN of the called node (target).
+    pub to_fqn: String,
+    /// BFS depth at which this edge was discovered (1-indexed from root).
+    pub depth: u32,
+    pub provenance: EdgeProvenance,
+}
+
+/// Options controlling BFS traversal behaviour.
+#[derive(Debug, Clone)]
+pub struct TraversalOptions {
+    /// Maximum traversal depth (1–10, default 3).
+    pub depth: u32,
+    /// Maximum edges to return per page (1–200, default 50).
+    pub limit: usize,
+    /// Opaque cursor for continuation (base64-encoded offset).
+    pub cursor: Option<String>,
+}
+
+impl Default for TraversalOptions {
+    fn default() -> Self {
+        Self {
+            depth: DEFAULT_DEPTH,
+            limit: DEFAULT_LIMIT,
+            cursor: None,
+        }
+    }
+}
+
+impl TraversalOptions {
+    /// Clamp depth and limit to valid ranges.
+    pub fn clamp(mut self) -> Self {
+        self.depth = self.depth.clamp(1, MAX_DEPTH);
+        self.limit = self.limit.clamp(1, MAX_LIMIT);
+        self
+    }
+}
+
+/// Result of a caller/callee BFS traversal.
+#[derive(Debug, Serialize)]
+pub struct TraversalResult {
+    /// The root node from which traversal started.
+    pub root: TraversalNode,
+    /// All unique nodes encountered (excluding root).
+    pub nodes: Vec<TraversalNode>,
+    /// All edges traversed, in BFS order.
+    pub edges: Vec<TraversalEdge>,
+    /// Whether any cycle was detected during BFS.
+    pub cycles_detected: bool,
+    /// Cursor for the next page, absent if this is the last page.
+    pub next_cursor: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_opts_are_valid() {
+        let opts = TraversalOptions::default().clamp();
+        assert_eq!(opts.depth, DEFAULT_DEPTH);
+        assert_eq!(opts.limit, DEFAULT_LIMIT);
+    }
+
+    #[test]
+    fn clamp_caps_depth_and_limit() {
+        let opts = TraversalOptions {
+            depth: 999,
+            limit: 9999,
+            cursor: None,
+        }
+        .clamp();
+        assert_eq!(opts.depth, MAX_DEPTH);
+        assert_eq!(opts.limit, MAX_LIMIT);
+    }
+
+    #[test]
+    fn provenance_serializes_snake_case() {
+        let j = serde_json::to_string(&EdgeProvenance::DynCandidate).unwrap();
+        assert_eq!(j, "\"dyn_candidate\"");
+        let j = serde_json::to_string(&EdgeProvenance::Monomorph).unwrap();
+        assert_eq!(j, "\"monomorph\"");
+        let j = serde_json::to_string(&EdgeProvenance::Direct).unwrap();
+        assert_eq!(j, "\"direct\"");
+    }
+}

--- a/docs/adr/ADR-008-caller-callee-traversal-api.md
+++ b/docs/adr/ADR-008-caller-callee-traversal-api.md
@@ -1,0 +1,107 @@
+# ADR-008 — Caller/Callee Traversal API (REQ-DP-03)
+
+**Status:** Accepted  
+**Deciders:** Architect, Board  
+**Implementing issue:** RUSAA-74
+
+---
+
+## Context
+
+The data-plane requires depth-limited BFS traversal of the Neo4j call graph to answer
+"who calls X?" and "what does X call?". The existing `/tools/get_callers` endpoint is
+workspace-header–based, depth-capped at 5, and returns flat lists without provenance.
+The new v1 API uses path-based repo scoping, supports up to depth 10, returns structured
+graph results (nodes + edges), and annotates each edge with dispatch provenance.
+
+---
+
+## Decision
+
+### §3.3 — Caller/Callee Traversal Endpoints
+
+#### Endpoints
+
+```
+GET /v1/repos/{repo_id}/items/{fqn_b64}/callers
+GET /v1/repos/{repo_id}/items/{fqn_b64}/callees
+```
+
+`repo_id` — workspace identifier (matches `X-Workspace-Id` in legacy endpoints).  
+`fqn_b64` — URL-safe base64-encoded fully-qualified name (no padding).
+
+#### Query Parameters
+
+| Parameter | Type   | Default | Max | Description                            |
+|-----------|--------|---------|-----|----------------------------------------|
+| `depth`   | uint   | 3       | 10  | BFS traversal depth                    |
+| `limit`   | uint   | 50      | 200 | Max edges per page                     |
+| `cursor`  | string | —       | —   | Opaque continuation cursor             |
+
+#### Response Shape
+
+```json
+{
+  "root": {
+    "fqn": "crate::module::my_fn",
+    "name": "my_fn",
+    "kind": "Function",
+    "file_path": "src/module.rs",
+    "line": 42
+  },
+  "nodes": [
+    { "fqn": "...", "name": "...", "kind": "...", "file_path": "...", "line": null }
+  ],
+  "edges": [
+    {
+      "from_fqn": "caller::fn",
+      "to_fqn": "crate::module::my_fn",
+      "depth": 1,
+      "provenance": "direct"
+    }
+  ],
+  "cycles_detected": false,
+  "next_cursor": "eyJvZmZzZXQiOjUwfQ"
+}
+```
+
+#### Edge Provenance
+
+| Value           | Meaning                                                      |
+|-----------------|--------------------------------------------------------------|
+| `direct`        | Static call via `CALLS` edge; no type specialisation         |
+| `monomorph`     | `CALL_INSTANTIATES` edge, or `CALLS` with concrete type args |
+| `dyn_candidate` | `CALLS` edge with `dispatch = "dynamic"` property            |
+
+#### BFS Algorithm
+
+1. Start frontier = {`root_fqn`}; visited = {`root_fqn`}
+2. For each depth level:
+   - Query Neo4j for immediate neighbors via `CALLS` and `CALL_INSTANTIATES` edges
+   - Skip nodes already in visited (record `cycles_detected = true`)
+   - Add new nodes to visited and the next frontier
+3. Collect (edge, provenance) pairs in BFS order
+4. Apply cursor offset + limit to produce the page
+5. Emit `next_cursor` when more edges remain
+
+---
+
+## Implementation
+
+- **Library crate:** `crates/rb-query` — `CallGraphTraverser`, `TraversalOptions`,
+  `TraversalResult`, `EdgeProvenance`, cursor encode/decode
+- **Handler module:** `services/api/src/handlers/repos.rs` — Axum handlers, base64 FQN
+  decoding, parameter validation
+- **Route wiring:** `services/api/src/main.rs`
+
+---
+
+## Consequences
+
+- Adds two new endpoints under the `/v1/repos/` namespace (stable, repo-scoped).
+- `CALL_INSTANTIATES` edges are queried but currently return 0 rows; provenance for
+  monomorphized calls is derived from `CALLS.concrete_types` until ingestion emits
+  `CALL_INSTANTIATES`.
+- Cursor encodes a simple offset; ordering is BFS insertion order (deterministic for
+  a given graph state).
+- Multi-tenancy guaranteed: workspace label injected into every Cypher pattern.

--- a/docs/api-spec.md
+++ b/docs/api-spec.md
@@ -1937,3 +1937,146 @@ Get full detail for a bench run including per-case results.
   ]
 }
 ```
+
+---
+
+## Data Plane — Caller/Callee Traversal (REQ-DP-03)
+
+BFS traversal of the Neo4j call graph scoped to a workspace/repo. Implemented in `crates/rb-query`.
+
+All endpoints under this section are tenant-isolated: `repo_id` maps to the Neo4j workspace label and no cross-tenant edges are returned.
+
+### GET /v1/repos/{repo_id}/items/{fqn_b64}/callers
+
+Returns all functions that transitively call the target item, up to `depth` hops (BFS backward over `CALLS` and `CALL_INSTANTIATES` edges).
+
+#### Path Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `repo_id` | string | Workspace identifier (used as Neo4j workspace label) |
+| `fqn_b64` | string | URL-safe base64-encoded fully-qualified name of the target item |
+
+To encode a FQN: `base64url(fqn)` with no padding (RFC 4648 §5 without `=`).
+
+#### Query Parameters
+
+| Parameter | Type | Default | Max | Description |
+|-----------|------|---------|-----|-------------|
+| `depth` | integer | `3` | `10` | BFS traversal depth |
+| `limit` | integer | `50` | `200` | Max edges to return per page |
+| `cursor` | string | — | — | Opaque continuation token from prior response |
+
+#### Response
+
+**`200 OK`** — `application/json`
+
+```json
+{
+  "root": {
+    "fqn": "serde_json::from_str",
+    "name": "from_str",
+    "kind": "fn",
+    "file_path": "src/lib.rs",
+    "line": 101
+  },
+  "nodes": [
+    {
+      "fqn": "my_app::config::load_config",
+      "name": "load_config",
+      "kind": "fn",
+      "file_path": "src/config.rs",
+      "line": 23
+    }
+  ],
+  "edges": [
+    {
+      "from_fqn": "my_app::config::load_config",
+      "to_fqn": "serde_json::from_str",
+      "depth": 1,
+      "provenance": "direct"
+    }
+  ],
+  "cycles_detected": false,
+  "next_cursor": null
+}
+```
+
+#### Response Schema
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `root` | `TraversalNode` | The item whose callers were requested |
+| `nodes` | `TraversalNode[]` | All unique nodes encountered (excluding root), deduplicated |
+| `edges` | `TraversalEdge[]` | BFS-ordered edges; length ≤ `limit` |
+| `cycles_detected` | boolean | `true` if any cycle was detected during traversal |
+| `next_cursor` | string? | Opaque cursor; absent when no more pages |
+
+**`TraversalNode`**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `fqn` | string | Fully-qualified name |
+| `name` | string | Short name (last segment) |
+| `kind` | string? | Item kind: `fn`, `method`, `closure`, etc. |
+| `file_path` | string? | Source file path relative to repo root |
+| `line` | integer? | Line number of definition |
+
+**`TraversalEdge`**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `from_fqn` | string | Calling node FQN |
+| `to_fqn` | string | Called node FQN |
+| `depth` | integer | BFS depth at which this edge was discovered (1-indexed) |
+| `provenance` | `EdgeProvenance` | `direct` / `monomorph` / `dyn_candidate` |
+
+**`EdgeProvenance`**
+
+| Value | Description |
+|-------|-------------|
+| `direct` | Static direct call via a `CALLS` edge with static dispatch |
+| `monomorph` | Monomorphized generic — `CALL_INSTANTIATES` edge or `CALLS` edge with concrete type args |
+| `dyn_candidate` | Dynamic dispatch candidate — `CALLS` edge with `dispatch = "dynamic"` |
+
+#### Errors
+
+| Status | Code | Condition |
+|--------|------|-----------|
+| `400` | `BAD_REQUEST` | Invalid `repo_id`, malformed `fqn_b64`, `depth > 10`, `limit > 200`, or invalid cursor |
+| `500` | `NEO4J_ERROR` | Graph query failed |
+
+#### cURL Example
+
+```bash
+# Encode FQN
+FQN_B64=$(echo -n "serde_json::from_str" | base64 | tr '+/' '-_' | tr -d '=')
+
+curl "http://localhost:8088/v1/repos/my-workspace/items/${FQN_B64}/callers?depth=3&limit=50"
+```
+
+---
+
+### GET /v1/repos/{repo_id}/items/{fqn_b64}/callees
+
+Returns all functions transitively called by the target item, up to `depth` hops (BFS forward over `CALLS` and `CALL_INSTANTIATES` edges).
+
+Path parameters, query parameters, response schema, and errors are identical to the [callers endpoint](#get-v1reposrepo_iditemsfqn_b64callers) above. The traversal direction is reversed: edges go from the root outward toward callees.
+
+#### cURL Example
+
+```bash
+FQN_B64=$(echo -n "my_app::main" | base64 | tr '+/' '-_' | tr -d '=')
+
+curl "http://localhost:8088/v1/repos/my-workspace/items/${FQN_B64}/callees?depth=5&limit=100"
+```
+
+#### Pagination
+
+Both endpoints support cursor-based pagination:
+
+1. Make initial request (no `cursor`).
+2. If `next_cursor` is non-null, pass it as `?cursor=<value>` to fetch the next page.
+3. Repeat until `next_cursor` is null.
+
+The cursor encodes the current page offset and is opaque — do not parse or construct it manually.

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -6,6 +6,7 @@ import type {
   ExecuteResponse,
   FileNode,
   ResetResponse,
+  TraversalResult,
   Workspace,
   WorkspaceStats,
 } from '../types'
@@ -144,6 +145,42 @@ export function commitWorkspace(
 
 export function resetWorkspace(id: string): Promise<ResetResponse> {
   return post(`/workspaces/${id}/reset`)
+}
+
+// ─── Call Graph Traversal (REQ-DP-03) ────────────────────────────────────────
+
+export interface TraversalParams {
+  depth?: number
+  limit?: number
+  cursor?: string
+}
+
+function fqnToB64(fqn: string): string {
+  return btoa(fqn).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+}
+
+function traversalQuery(params: TraversalParams): string {
+  const parts: string[] = []
+  if (params.depth != null) parts.push(`depth=${params.depth}`)
+  if (params.limit != null) parts.push(`limit=${params.limit}`)
+  if (params.cursor != null) parts.push(`cursor=${encodeURIComponent(params.cursor)}`)
+  return parts.length ? `?${parts.join('&')}` : ''
+}
+
+export function getCallers(
+  repoId: string,
+  fqn: string,
+  params: TraversalParams = {},
+): Promise<TraversalResult> {
+  return get(`/v1/repos/${repoId}/items/${fqnToB64(fqn)}/callers${traversalQuery(params)}`)
+}
+
+export function getCallees(
+  repoId: string,
+  fqn: string,
+  params: TraversalParams = {},
+): Promise<TraversalResult> {
+  return get(`/v1/repos/${repoId}/items/${fqnToB64(fqn)}/callees${traversalQuery(params)}`)
 }
 
 // ─── SSE stream ───────────────────────────────────────────────────────────────

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -216,3 +216,38 @@ export interface ResetResponse {
   message: string
   head_sha: string
 }
+
+// ─── Call Graph Traversal (REQ-DP-03) ────────────────────────────────────────
+
+/** Dispatch provenance for a call graph edge. */
+export type EdgeProvenance = 'direct' | 'monomorph' | 'dyn_candidate'
+
+/** A node discovered during BFS traversal of the call graph. */
+export interface TraversalNode {
+  fqn: string
+  name: string
+  kind?: string
+  file_path?: string
+  line?: number
+}
+
+/** A directed edge discovered during BFS traversal. */
+export interface TraversalEdge {
+  from_fqn: string
+  to_fqn: string
+  /** BFS depth at which this edge was discovered (1-indexed from root). */
+  depth: number
+  provenance: EdgeProvenance
+}
+
+/**
+ * Response from GET /v1/repos/{repo_id}/items/{fqn_b64}/callers
+ * and GET /v1/repos/{repo_id}/items/{fqn_b64}/callees.
+ */
+export interface TraversalResult {
+  root: TraversalNode
+  nodes: TraversalNode[]
+  edges: TraversalEdge[]
+  cycles_detected: boolean
+  next_cursor?: string | null
+}

--- a/services/api/Cargo.toml
+++ b/services/api/Cargo.toml
@@ -58,6 +58,12 @@ neo4rs = "0.7"
 # Shared types
 rustbrain-common = { path = "../../crates/rustbrain-common" }
 
+# Data-plane query engine (REQ-DP-03)
+rb-query = { path = "../../crates/rb-query" }
+
+# Base64 for FQN path decoding
+base64 = "0.22"
+
 [dev-dependencies]
 # Integration test HTTP client
 reqwest = { version = "0.12", features = ["json", "stream"] }

--- a/services/api/src/handlers/mod.rs
+++ b/services/api/src/handlers/mod.rs
@@ -12,6 +12,7 @@
 //! | [`typecheck`] | `GET /tools/find_calls_with_type`, `GET /tools/find_trait_impls_for_type` |
 //! | [`ingestion`] | `GET /api/ingestion/progress` |
 //! | [`playground`] | Playground HTML serving |
+//! | [`repos`] | `GET /v1/repos/:repo_id/items/:fqn_b64/callers`, `/callees` (REQ-DP-03) |
 
 pub mod artifacts;
 pub mod benchmarker;
@@ -26,6 +27,7 @@ pub mod items;
 pub mod keys;
 pub mod pg_query;
 pub mod playground;
+pub mod repos;
 pub mod search;
 pub mod tasks;
 pub mod typecheck;

--- a/services/api/src/handlers/repos.rs
+++ b/services/api/src/handlers/repos.rs
@@ -1,0 +1,267 @@
+//! REQ-DP-03: caller/callee traversal handlers.
+//!
+//! Endpoints:
+//! - `GET /v1/repos/{repo_id}/items/{fqn_b64}/callers`
+//! - `GET /v1/repos/{repo_id}/items/{fqn_b64}/callees`
+//!
+//! `repo_id` maps to the workspace identifier used for Neo4j tenant isolation.
+//! `fqn_b64` is the URL-safe base64-encoded fully qualified name of the target item.
+//!
+//! # Query parameters
+//!
+//! | Parameter | Default | Max   | Description                                  |
+//! |-----------|---------|-------|----------------------------------------------|
+//! | `depth`   | 3       | 10    | BFS traversal depth                          |
+//! | `limit`   | 50      | 200   | Max edges to return per page                 |
+//! | `cursor`  | —       | —     | Opaque continuation token from prior response|
+
+use axum::{
+    extract::{Path, Query, State},
+    Json,
+};
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
+use rb_query::{
+    CallGraphTraverser, TraversalOptions, TraversalResult,
+    types::{DEFAULT_DEPTH, DEFAULT_LIMIT, MAX_DEPTH, MAX_LIMIT},
+};
+use serde::Deserialize;
+use tracing::debug;
+
+use crate::errors::AppError;
+use crate::neo4j::WorkspaceContext;
+use crate::state::AppState;
+
+// =============================================================================
+// Request types
+// =============================================================================
+
+/// Path parameters for the v1 caller/callee endpoints.
+#[derive(Debug, Deserialize)]
+pub struct RepoItemPath {
+    /// Workspace / repository identifier (used as Neo4j workspace label).
+    pub repo_id: String,
+    /// URL-safe base64-encoded fully qualified name.
+    pub fqn_b64: String,
+}
+
+/// Query parameters common to both callers and callees endpoints.
+#[derive(Debug, Deserialize)]
+pub struct TraversalQuery {
+    /// BFS depth (1–10, default 3).
+    #[serde(default = "default_depth")]
+    pub depth: u32,
+    /// Max edges per page (1–200, default 50).
+    #[serde(default = "default_limit")]
+    pub limit: usize,
+    /// Opaque cursor returned by a previous response.
+    pub cursor: Option<String>,
+}
+
+fn default_depth() -> u32 {
+    DEFAULT_DEPTH
+}
+
+fn default_limit() -> usize {
+    DEFAULT_LIMIT
+}
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+/// Decode a URL-safe base64 FQN from the path segment.
+fn decode_fqn(fqn_b64: &str) -> Result<String, AppError> {
+    let bytes = URL_SAFE_NO_PAD.decode(fqn_b64).map_err(|_| {
+        AppError::BadRequest(format!(
+            "fqn_b64 is not valid URL-safe base64: '{fqn_b64}'"
+        ))
+    })?;
+    String::from_utf8(bytes)
+        .map_err(|_| AppError::BadRequest("fqn_b64 decoded bytes are not valid UTF-8".to_string()))
+}
+
+/// Validate traversal query parameters and build `TraversalOptions`.
+fn build_opts(q: TraversalQuery) -> Result<TraversalOptions, AppError> {
+    if q.depth > MAX_DEPTH as u32 {
+        return Err(AppError::BadRequest(format!(
+            "depth must be <= {MAX_DEPTH}"
+        )));
+    }
+    if q.limit > MAX_LIMIT {
+        return Err(AppError::BadRequest(format!(
+            "limit must be <= {MAX_LIMIT}"
+        )));
+    }
+    Ok(TraversalOptions {
+        depth: q.depth,
+        limit: q.limit,
+        cursor: q.cursor,
+    })
+}
+
+/// Build a `CallGraphTraverser` scoped to the given repo/workspace.
+fn make_traverser(
+    state: &AppState,
+    repo_id: &str,
+) -> Result<CallGraphTraverser, AppError> {
+    let ctx = WorkspaceContext::new(repo_id.to_string())?;
+    Ok(CallGraphTraverser::new(
+        state.neo4j_graph.clone(),
+        ctx.workspace_label(),
+    ))
+}
+
+/// Map `anyhow::Error` from the traversal engine to `AppError`.
+fn traversal_err(err: anyhow::Error) -> AppError {
+    let msg = err.to_string();
+    if msg.contains("invalid cursor") {
+        AppError::BadRequest(msg)
+    } else {
+        AppError::Neo4j(msg)
+    }
+}
+
+// =============================================================================
+// Handlers
+// =============================================================================
+
+/// Returns all functions that call the target item, up to `depth` hops.
+///
+/// BFS traverses `CALLS` and `CALL_INSTANTIATES` edges backward (toward callers).
+/// Cycle detection prevents infinite loops in recursive call graphs.
+/// Results are paginated; use `next_cursor` to fetch the next page.
+///
+/// # Errors
+///
+/// - `400 BAD_REQUEST` — invalid `repo_id`, malformed `fqn_b64`, or invalid query params.
+/// - `500 NEO4J_ERROR` — graph query failed.
+pub async fn get_callers(
+    State(state): State<AppState>,
+    Path(path): Path<RepoItemPath>,
+    Query(query): Query<TraversalQuery>,
+) -> Result<Json<TraversalResult>, AppError> {
+    let fqn = decode_fqn(&path.fqn_b64)?;
+    let opts = build_opts(query)?;
+
+    debug!(repo_id = %path.repo_id, fqn = %fqn, depth = opts.depth, "get_callers");
+
+    let traverser = make_traverser(&state, &path.repo_id)?;
+    let result = traverser
+        .get_callers(&fqn, opts)
+        .await
+        .map_err(traversal_err)?;
+
+    Ok(Json(result))
+}
+
+/// Returns all functions called by the target item, up to `depth` hops.
+///
+/// BFS traverses `CALLS` and `CALL_INSTANTIATES` edges forward (toward callees).
+/// Cycle detection prevents infinite loops in recursive call graphs.
+/// Results are paginated; use `next_cursor` to fetch the next page.
+///
+/// # Errors
+///
+/// - `400 BAD_REQUEST` — invalid `repo_id`, malformed `fqn_b64`, or invalid query params.
+/// - `500 NEO4J_ERROR` — graph query failed.
+pub async fn get_callees(
+    State(state): State<AppState>,
+    Path(path): Path<RepoItemPath>,
+    Query(query): Query<TraversalQuery>,
+) -> Result<Json<TraversalResult>, AppError> {
+    let fqn = decode_fqn(&path.fqn_b64)?;
+    let opts = build_opts(query)?;
+
+    debug!(repo_id = %path.repo_id, fqn = %fqn, depth = opts.depth, "get_callees");
+
+    let traverser = make_traverser(&state, &path.repo_id)?;
+    let result = traverser
+        .get_callees(&fqn, opts)
+        .await
+        .map_err(traversal_err)?;
+
+    Ok(Json(result))
+}
+
+// =============================================================================
+// Unit tests
+// =============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn decode_fqn_roundtrip() {
+        let fqn = "crate::module::my_function";
+        let encoded = URL_SAFE_NO_PAD.encode(fqn.as_bytes());
+        assert_eq!(decode_fqn(&encoded).unwrap(), fqn);
+    }
+
+    #[test]
+    fn decode_fqn_rejects_bad_base64() {
+        let err = decode_fqn("not!valid!base64").unwrap_err();
+        assert!(err.to_string().contains("not valid URL-safe base64"));
+    }
+
+    #[test]
+    fn decode_fqn_rejects_non_utf8() {
+        // Valid base64 of 0xFF bytes (invalid UTF-8)
+        let encoded = URL_SAFE_NO_PAD.encode([0xFF, 0xFE]);
+        let err = decode_fqn(&encoded).unwrap_err();
+        assert!(err.to_string().contains("not valid UTF-8"));
+    }
+
+    #[test]
+    fn build_opts_defaults() {
+        let q = TraversalQuery {
+            depth: DEFAULT_DEPTH,
+            limit: DEFAULT_LIMIT,
+            cursor: None,
+        };
+        let opts = build_opts(q).unwrap();
+        assert_eq!(opts.depth, DEFAULT_DEPTH);
+        assert_eq!(opts.limit, DEFAULT_LIMIT);
+        assert!(opts.cursor.is_none());
+    }
+
+    #[test]
+    fn build_opts_rejects_depth_over_max() {
+        let q = TraversalQuery {
+            depth: MAX_DEPTH as u32 + 1,
+            limit: DEFAULT_LIMIT,
+            cursor: None,
+        };
+        let err = build_opts(q).unwrap_err();
+        assert!(err.to_string().contains("depth must be"));
+    }
+
+    #[test]
+    fn build_opts_rejects_limit_over_max() {
+        let q = TraversalQuery {
+            depth: DEFAULT_DEPTH,
+            limit: MAX_LIMIT + 1,
+            cursor: None,
+        };
+        let err = build_opts(q).unwrap_err();
+        assert!(err.to_string().contains("limit must be"));
+    }
+
+    #[test]
+    fn traversal_err_maps_cursor_to_bad_request() {
+        let err = anyhow::anyhow!("invalid cursor: base64 decode failed");
+        match traversal_err(err) {
+            AppError::BadRequest(_) => {}
+            other => panic!("expected BadRequest, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn traversal_err_maps_other_to_neo4j() {
+        let err = anyhow::anyhow!("connection refused");
+        match traversal_err(err) {
+            AppError::Neo4j(_) => {}
+            other => panic!("expected Neo4j, got {:?}", other),
+        }
+    }
+}

--- a/services/api/src/main.rs
+++ b/services/api/src/main.rs
@@ -290,6 +290,15 @@ async fn main() -> anyhow::Result<()> {
         .route("/tools/query_graph", post(handlers::graph::query_graph))
         // Read-only SQL query
         .route("/tools/pg_query", post(handlers::pg_query::pg_query))
+        // v1 data-plane: caller/callee traversal (REQ-DP-03)
+        .route(
+            "/v1/repos/:repo_id/items/:fqn_b64/callers",
+            get(handlers::repos::get_callers),
+        )
+        .route(
+            "/v1/repos/:repo_id/items/:fqn_b64/callees",
+            get(handlers::repos::get_callees),
+        )
         // API key management (admin only)
         .route(
             "/api/keys",


### PR DESCRIPTION
## Summary

- New `crates/rb-query` library: `CallGraphTraverser` with BFS over `CALLS` + `CALL_INSTANTIATES` edges, per-edge provenance (`direct`/`monomorph`/`dyn_candidate`), cycle detection via visited set, cursor-based pagination
- Two new v1 endpoints wired in `services/api`:
  - `GET /v1/repos/{repo_id}/items/{fqn_b64}/callers`
  - `GET /v1/repos/{repo_id}/items/{fqn_b64}/callees`
- `fqn_b64` = URL-safe base64-encoded FQN; `repo_id` maps to Neo4j workspace label
- Default depth 3, max 10; default limit 50, max 200
- ADR-008 added to `docs/adr/`

## Test plan

- [x] `cargo check -p rb-query` — clean
- [x] `cargo check -p rustbrain-api` — clean
- [x] `cargo test -p rb-query` — 18/18 unit tests pass (cursor, provenance, BFS result pagination, cycle flag, node deduplication)
- [x] `cargo test -p rustbrain-api -- handlers::repos` — 8/8 unit tests pass (FQN decode, opts validation, error mapping)
- [x] `cargo clippy -p rb-query -p rustbrain-api --lib` — clean
- [ ] Integration test against live Neo4j: verify callers/callees return correct graph for an ingested crate (requires running stack)

## References

- ADR: `docs/adr/ADR-008-caller-callee-traversal-api.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)